### PR TITLE
shift: Updating documentation to be more clear

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -20,30 +20,30 @@ type builder FSM
 type initer builder
 
 // Insert returns a FSM builder with the provided insert status.
-func (c initer) Insert(st Status, inserter Inserter, next ...Status) builder {
+func (c initer) Insert(st Status, stInserter Inserter, nextAllowed ...Status) builder {
 	c.states[st] = status{
 		st:     st,
-		req:    inserter,
+		req:    stInserter,
 		t:      st,
 		insert: false,
-		next:   toMap(next),
+		next:   toMap(nextAllowed),
 	}
 	c.insertStatus = st
 	return builder(c)
 }
 
 // Update returns a FSM builder with the provided status update added.
-func (b builder) Update(st Status, updater Updater, next ...Status) builder {
+func (b builder) Update(st Status, stUpdater Updater, nextAllowed ...Status) builder {
 	if _, has := b.states[st]; has {
 		// Ok to panic since it is build time.
 		panic("state already added")
 	}
 	b.states[st] = status{
 		st:     st,
-		req:    updater,
+		req:    stUpdater,
 		t:      st,
 		insert: false,
-		next:   toMap(next),
+		next:   toMap(nextAllowed),
 	}
 	return b
 }

--- a/shift.go
+++ b/shift.go
@@ -1,10 +1,39 @@
 // Package shift provides the persistence layer for a simple "finite state machine"
 // domain model with validation, explicit fields and reflex events per state change.
 //
+// Defining an FSM
+//
 // shift.NewFSM builds a FSM instance that allows specific mutations of
 // the domain model in the underlying sql table via inserts and updates.
 // All mutations update the status of the model, mutates some fields and
 // inserts a reflex event.
+//
+// There needs to be at least one insert status defined and 0..n update
+// statuses defined. When defining statuses, it is useful to think of the
+// following model:
+//
+//        TargetState, UpdaterForTargetState, TransitionableStatesAfterThisState
+//
+// This is an example that follows this model:
+//
+//        Insert(InsertStatus, insertReq{}, PendingStatus).
+//        Update(PendingStatus, pendingReq{}, errorStatus, authorizedStatus).
+//        Update(AuthorizedStatus, authorizedReq{}, errorStatus).
+//        Update(ErrorState,  errorReq{}, PendingStatus).
+//        Build()
+//
+// It is best to avoid the following interpretation when defining a FSM:
+//
+//        FromState, UpdaterForTargetState, TargetStates
+//
+// This is an example that follows this thought pattern (it is INCORRECT!):
+//
+//        Insert(InsertStatus, insertReq{}, PendingStatus).
+//        Update(PendingStatus, updateReq{}, errorStatus, authorizedStatus).
+//        Update(AuthorizedStatus, errorReq{}, errorStatus).
+//        Update(ErrorState,  pendingReq{}, PendingStatus).
+//        Build()
+//
 package shift
 
 import (


### PR DESCRIPTION
If you don't consult someone with knowledge of shift, it is possible to misunderstand the usage of the shift API. This PR makes it easier to reason with building FSMs