### PR TITLE
Add InsertTx and UpdateTx to ArcFSM

### DIFF
--- a/arc.go
+++ b/arc.go
@@ -81,9 +81,14 @@ func (fsm *ArcFSM) Insert(ctx context.Context, dbc *sql.DB, st Status, inserter 
 	if err != nil {
 		return 0, err
 	}
-	defer notify()
 
-	return id, tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return 0, err
+	}
+
+	notify()
+	return id, nil
 }
 
 func (fsm *ArcFSM) InsertTx(ctx context.Context, tx *sql.Tx, st Status, inserter Inserter) (int64, rsql.NotifyFunc, error) {
@@ -112,9 +117,14 @@ func (fsm *ArcFSM) Update(ctx context.Context, dbc *sql.DB, from, to Status, upd
 	if err != nil {
 		return err
 	}
-	defer notify()
 
-	return tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	notify()
+	return nil
 }
 
 func (fsm *ArcFSM) UpdateTx(ctx context.Context, tx *sql.Tx, from, to Status, updater Updater) (rsql.NotifyFunc, error) {

--- a/shift.go
+++ b/shift.go
@@ -123,9 +123,14 @@ func (fsm *FSM) Insert(ctx context.Context, dbc *sql.DB, inserter Inserter) (int
 	if err != nil {
 		return 0, err
 	}
-	defer notify()
 
-	return id, tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return 0, err
+	}
+
+	notify()
+	return id, nil
 }
 
 func (fsm *FSM) InsertTx(ctx context.Context, tx *sql.Tx, inserter Inserter) (int64, rsql.NotifyFunc, error) {
@@ -150,9 +155,14 @@ func (fsm *FSM) Update(ctx context.Context, dbc *sql.DB, from Status, to Status,
 	if err != nil {
 		return err
 	}
-	defer notify()
 
-	return tx.Commit()
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	notify()
+	return nil
 }
 
 func (fsm *FSM) UpdateTx(ctx context.Context, tx *sql.Tx, from Status, to Status, updater Updater) (rsql.NotifyFunc, error) {


### PR DESCRIPTION
This adds tx equivalents for the insert and update operations to ArcFSM, which FSM already had, but ArcFSM didn't.

It matches the way it's done in FSM: `Insert` and `Update` only start a transaction, call `InsertTx` / `UpdateTx` and commit. The Tx functions check if the state transition is allowed and call the respective private function.

No tests added as FSM's tx functions are not tested directly either, but they're tested indirectly via `Insert` and `Update`.