### PR TITLE
Generate mermaid diagrams from state machine

### DIFF
--- a/shiftgen/mermaid.go
+++ b/shiftgen/mermaid.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"slices"
+	"text/template"
+)
+
+type mermaidDirection string
+
+const (
+	unknownDirection     mermaidDirection = ""
+	topToBottomDirection mermaidDirection = "TB"
+	leftToRightDirection mermaidDirection = "LR"
+	rightToLeftDirection mermaidDirection = "RL"
+	bottomToTopDirection mermaidDirection = "BT"
+)
+
+type mermaidTransition struct {
+	From string
+	To   string
+}
+
+type points []string
+type transitions []mermaidTransition
+
+type mermaidFormat struct {
+	Direction      mermaidDirection
+	StartingPoints points
+	TerminalPoints points
+	Transitions    transitions
+}
+
+func (t *points) add(point string) {
+	// Check if point already exists
+	if slices.Contains(*t, point) {
+		return
+	}
+
+	*t = append(*t, point)
+}
+
+func (t *transitions) add(trans mermaidTransition) {
+	// Check if transition already exists
+	for _, val := range *t {
+		if val.From == trans.From && val.To == trans.To {
+			return
+		}
+	}
+
+	*t = append(*t, trans)
+}
+
+func generateMermaidDiagram(pkgPath string) (string, error) {
+	fs := token.NewFileSet()
+	asts, err := parser.ParseDir(fs, pkgPath, nil, 0)
+
+	if err != nil {
+		return "", err
+	}
+
+	var diagram = &mermaidFormat{
+		Direction: leftToRightDirection,
+	}
+
+	for _, node := range asts {
+		shiftAlias := getShiftAlias(node)
+
+		ast.Inspect(node, func(n ast.Node) bool {
+			callExpr, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+
+			return buildMermaidDiagram(callExpr, diagram, shiftAlias)
+		})
+	}
+
+	return renderMermaidTpl(diagram)
+}
+
+func renderMermaidTpl(diagram *mermaidFormat) (string, error) {
+	t, err := template.New("").Parse(mermaidTemplate)
+
+	if err != nil {
+		return "", err
+	}
+
+	buf := new(bytes.Buffer)
+
+	err = t.Execute(buf, diagram)
+
+	return buf.String(), err
+}
+
+func getShiftAlias(node *ast.Package) string {
+	shiftAlias := "shift" // Default package name
+
+	ast.Inspect(node, func(n ast.Node) bool {
+		importSpec, ok := n.(*ast.ImportSpec)
+		if !ok {
+			return true
+		}
+		if importSpec.Path.Value == `"github.com/luno/shift"` {
+			if importSpec.Name != nil {
+				shiftAlias = importSpec.Name.Name
+			}
+			return false
+		}
+		return true
+	})
+
+	return shiftAlias
+}
+
+// buildMermaidDiagram captures information about .Insert and .Update calls.
+func buildMermaidDiagram(expr *ast.CallExpr, diagram *mermaidFormat, shiftAlias string) bool {
+	selectorExpr, ok := expr.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	// Check for the NewArcFSM at the beginning of the chain
+	if isShiftCall(expr, "NewArcFSM", shiftAlias) {
+		if selectorExpr.Sel.Name == "Insert" {
+			if len(expr.Args) > 0 {
+				firstArg := formatArg(expr.Args[0])
+				diagram.StartingPoints.add(firstArg)
+			}
+		}
+
+		if selectorExpr.Sel.Name == "Update" {
+			if len(expr.Args) >= 2 {
+				firstArg := formatArg(expr.Args[0])
+				secondArg := formatArg(expr.Args[1])
+				diagram.Transitions.add(mermaidTransition{From: firstArg, To: secondArg})
+			}
+		}
+	}
+
+	// Check for the NewFSM at the beginning of the chain
+	if isShiftCall(expr, "NewFSM", shiftAlias) {
+		if selectorExpr.Sel.Name == "Insert" {
+			if len(expr.Args) == 2 {
+				firstArg := formatArg(expr.Args[0])
+				diagram.StartingPoints.add(firstArg)
+			} else if len(expr.Args) > 2 {
+				firstArg := formatArg(expr.Args[0])
+				diagram.StartingPoints.add(firstArg)
+
+				for _, arg := range expr.Args[2:] {
+					diagram.Transitions.add(mermaidTransition{From: firstArg, To: formatArg(arg)})
+				}
+			}
+		}
+
+		if selectorExpr.Sel.Name == "Update" {
+			if len(expr.Args) == 2 {
+				diagram.TerminalPoints.add(formatArg(expr.Args[0]))
+			} else if len(expr.Args) > 2 {
+				firstArg := formatArg(expr.Args[0])
+
+				for _, arg := range expr.Args[2:] {
+					diagram.Transitions.add(mermaidTransition{From: firstArg, To: formatArg(arg)})
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+// isShiftCall checks if the expression is a chain of method calls starting with the shift package alias.
+func isShiftCall(expr *ast.CallExpr, methodCall, shiftAlias string) bool {
+	for {
+		selectorExpr, ok := expr.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return false
+		}
+		if selectorExpr.Sel.Name == methodCall {
+			ident, ok := selectorExpr.X.(*ast.Ident)
+			if !ok {
+				return false
+			}
+			if ident.Name == shiftAlias {
+				return true
+			}
+		}
+		if callExpr, ok := selectorExpr.X.(*ast.CallExpr); ok {
+			expr = callExpr
+			continue
+		}
+		return false
+	}
+}
+
+func formatArg(arg ast.Expr) string {
+	switch a := arg.(type) {
+	case *ast.Ident:
+		return a.Name
+	case *ast.SelectorExpr:
+		if _, ok := a.X.(*ast.Ident); ok {
+			return a.Sel.Name
+		}
+	}
+
+	return fmt.Sprintf("%s", arg)
+}

--- a/shiftgen/shiftgen.go
+++ b/shiftgen/shiftgen.go
@@ -6,6 +6,8 @@
 // MetadataInserter or MetadataUpdater since it is orthogonal to inserting
 // and updating domain entity rows.
 //
+// To generate a mermaid state machine diagram, use the -mermaid flag.
+//
 //	Usage:
 //	  //go:generate shiftgen -table=model_table -inserter=InsertReq -updaters=UpdateReq,CompleteReq
 package main
@@ -57,6 +59,10 @@ var (
 		"output filename")
 	quoteChar = flag.String("quote_char", "`",
 		"Character to use when quoting column names")
+	mermaid = flag.Bool("mermaid", false,
+		"Generate mermaid state machine diagram")
+	mermaidOut = flag.String("mermaid_out", "shift_gen.mmd",
+		"Output filename for mermaid state machine diagram")
 )
 
 var ErrIDTypeMismatch = errors.New("Inserters and updaters' ID fields should have matching types", j.C("ERR_3db87b866daeda57"))
@@ -117,6 +123,20 @@ func main() {
 
 	if err = os.WriteFile(filePath, src, 0o644); err != nil {
 		log.Fatal(errors.Wrap(err, "Error writing file"))
+	}
+
+	if *mermaid {
+		mermaidFilePath := path.Join(pwd, *mermaidOut)
+
+		mmd, err := generateMermaidDiagram(pwd)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err = os.WriteFile(mermaidFilePath, []byte(mmd), 0o644); err != nil {
+			log.Fatal(errors.Wrap(err, "Error writing file"))
+		}
 	}
 }
 

--- a/shiftgen/shiftgen_test.go
+++ b/shiftgen/shiftgen_test.go
@@ -69,6 +69,37 @@ func TestGen(t *testing.T) {
 	}
 }
 
+func TestMermaid(t *testing.T) {
+	cc := []struct {
+		dir     string
+		outFile string
+	}{
+		{
+			dir:     "case_mermaid",
+			outFile: "shift_gen.mmd",
+		},
+		{
+			dir:     "case_mermaid_arcfsm",
+			outFile: "shift_gen.mmd",
+		},
+	}
+
+	for _, c := range cc {
+		t.Run(c.dir, func(t *testing.T) {
+			err := os.Setenv("GOFILE", "shiftgen_test.go")
+			jtest.RequireNil(t, err)
+			err = os.Setenv("GOLINE", "123")
+			jtest.RequireNil(t, err)
+
+			bb, err := generateMermaidDiagram(filepath.Join("testdata", c.dir))
+
+			jtest.RequireNil(t, err)
+			g := goldie.New(t)
+			g.Assert(t, filepath.Join(c.dir, c.outFile), []byte(bb))
+		})
+	}
+}
+
 func TestGenFailure(t *testing.T) {
 	cc := []struct {
 		dir       string

--- a/shiftgen/template.go
+++ b/shiftgen/template.go
@@ -100,3 +100,16 @@ func (一 {{.Type}}) Update(
 	return 一.ID, nil
 }{{ end }}
 `
+
+var mermaidTemplate = `stateDiagram-v2
+	Direction {{.Direction}}
+	{{range $key, $value := .StartingPoints }}
+	[*]-->{{$value}}
+	{{- end }}
+	{{range $key, $value := .Transitions }}
+	{{$value.From}}-->{{$value.To}}
+	{{- end }}
+	{{range $key, $value := .TerminalPoints }}
+	{{$value}}-->[*]
+	{{- end }}
+`

--- a/shiftgen/testdata/case_mermaid/case_basic.go
+++ b/shiftgen/testdata/case_mermaid/case_basic.go
@@ -1,0 +1,35 @@
+package case_basic
+
+import (
+	"github.com/luno/reflex/rsql"
+	"github.com/luno/shift"
+)
+
+var events = rsql.NewEventsTableInt("events")
+
+type status int
+
+const (
+	CREATED status = iota
+	PENDING
+	FAILED
+	COMPLETED
+)
+
+var fsm = shift.NewFSM(events).
+	Insert(CREATED, insert{}, PENDING, FAILED).
+	Update(PENDING, update{}, FAILED, COMPLETED).
+	Update(FAILED, update{}).
+	Update(COMPLETED, update{}).
+	Build()
+
+func (v status) ShiftStatus() int {
+	return int(v)
+}
+
+func (v status) ReflexType() int {
+	return int(v)
+}
+
+type insert struct{}
+type update struct{}

--- a/shiftgen/testdata/case_mermaid/shift_gen.mmd.golden
+++ b/shiftgen/testdata/case_mermaid/shift_gen.mmd.golden
@@ -1,0 +1,12 @@
+stateDiagram-v2
+	Direction LR
+	
+	[*]-->CREATED
+	
+	PENDING-->FAILED
+	PENDING-->COMPLETED
+	CREATED-->PENDING
+	CREATED-->FAILED
+	
+	COMPLETED-->[*]
+	FAILED-->[*]

--- a/shiftgen/testdata/case_mermaid_arcfsm/case_basic.go
+++ b/shiftgen/testdata/case_mermaid_arcfsm/case_basic.go
@@ -1,0 +1,36 @@
+package case_basic
+
+import (
+	"github.com/luno/reflex/rsql"
+	"github.com/luno/shift"
+)
+
+var events = rsql.NewEventsTableInt("events")
+
+type status int
+
+const (
+	CREATED status = iota
+	PENDING
+	FAILED
+	COMPLETED
+)
+
+var fsm = shift.NewArcFSM(events).
+	Insert(CREATED, insert{}).
+	Update(CREATED, FAILED, update{}).
+	Update(CREATED, PENDING, update{}).
+	Update(PENDING, FAILED, update{}).
+	Update(PENDING, COMPLETED, update{}).
+	Build()
+
+func (v status) ShiftStatus() int {
+	return int(v)
+}
+
+func (v status) ReflexType() int {
+	return int(v)
+}
+
+type insert struct{}
+type update struct{}

--- a/shiftgen/testdata/case_mermaid_arcfsm/shift_gen.mmd.golden
+++ b/shiftgen/testdata/case_mermaid_arcfsm/shift_gen.mmd.golden
@@ -1,0 +1,10 @@
+stateDiagram-v2
+	Direction LR
+	
+	[*]-->CREATED
+	
+	PENDING-->COMPLETED
+	PENDING-->FAILED
+	CREATED-->PENDING
+	CREATED-->FAILED
+	


### PR DESCRIPTION
This parses the AST of the state machine to generate a mermaid diagram.

The `shifgen` command has 2 new options: `-mermaid` and `-mermaid_out`. If the `-mermaid` flag is passed, a mermaid diagram will be generated at the `-mermaid_out` path (defaults to `shift_gen.mmd`)

Given the below state machine:

```go
var fsm = shift.NewFSM(events).
	Insert(CREATED, insert{}, PENDING, FAILED).
	Update(PENDING, update{}, FAILED, COMPLETED).
	Update(FAILED, update{}).
	Update(COMPLETED, update{}).
	Build()
```

The mermaid diagram will be generated as follows:

```mermaid
stateDiagram-v2
	Direction LR
	
	[*]-->CREATED
	
	PENDING-->FAILED
	PENDING-->COMPLETED
	CREATED-->PENDING
	CREATED-->FAILED
	
	COMPLETED-->[*]
	FAILED-->[*]
```

I have purposefully not added support for additional mermaid options (like direction) to keep the implementation simple. This can be added later if there is a need to specify custom options