### PR TITLE
ci: Update branch target to be main (others covered by PRs)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
### Changed
- Update branch target to be main (others covered by PRs). 
- This matches others (e.g. https://github.com/luno/luno-go/blob/main/.github/workflows/test.yml)