### PR TITLE
shift: Correct KV reporting for errors

### DIFF
--- a/shift.go
+++ b/shift.go
@@ -179,16 +179,16 @@ func (fsm *GenFSM[T]) Update(ctx context.Context, dbc *sql.DB, from Status, to S
 func (fsm *GenFSM[T]) UpdateTx(ctx context.Context, tx *sql.Tx, from Status, to Status, updater Updater[T]) (rsql.NotifyFunc, error) {
 	t, ok := fsm.states[to.ShiftStatus()]
 	if !ok {
-		return nil, errors.Wrap(ErrUnknownStatus, "unknown 'to' status", j.MKV{"from": fmt.Sprintf("%T", from), "to": fmt.Sprintf("%T", to)})
+		return nil, errors.Wrap(ErrUnknownStatus, "unknown 'to' status", j.MKV{"from": fmt.Sprintf("%v", from), "to": fmt.Sprintf("%v", to)})
 	}
 	if !sameType(t.req, updater) {
 		return nil, errors.Wrap(ErrInvalidType, "updater can't be used for this transition")
 	}
 	f, ok := fsm.states[from.ShiftStatus()]
 	if !ok {
-		return nil, errors.Wrap(ErrUnknownStatus, "unknown 'from' status", j.MKV{"from": fmt.Sprintf("%T", from), "to": fmt.Sprintf("%T", to)})
+		return nil, errors.Wrap(ErrUnknownStatus, "unknown 'from' status", j.MKV{"from": fmt.Sprintf("%v", from), "to": fmt.Sprintf("%v", to)})
 	} else if !f.next[to] {
-		return nil, errors.Wrap(ErrInvalidStateTransition, "", j.MKV{"from": fmt.Sprintf("%T", from), "to": fmt.Sprintf("%T", to)})
+		return nil, errors.Wrap(ErrInvalidStateTransition, "", j.MKV{"from": fmt.Sprintf("%v", from), "to": fmt.Sprintf("%v", to)})
 	}
 
 	return updateTx(ctx, tx, from, to, updater, fsm.events, t.t, fsm.options)

--- a/shift_test.go
+++ b/shift_test.go
@@ -3,7 +3,6 @@ package shift_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
@@ -291,10 +290,11 @@ func TestGenFSM_Update(t *testing.T) {
 
 	var unknownShiftStatus TestStatus = 999
 	tests := []struct {
-		name        string
-		from        shift.Status
-		to          shift.Status
-		expectedErr error
+		name   string
+		from   shift.Status
+		to     shift.Status
+		expErr error
+		expKVs j.MKV
 	}{
 		{
 			name: "Valid",
@@ -302,28 +302,31 @@ func TestGenFSM_Update(t *testing.T) {
 			to:   StatusUpdate,
 		},
 		{
-			name:        "Invalid State Transition",
-			from:        StatusComplete,
-			to:          StatusUpdate,
-			expectedErr: shift.ErrInvalidStateTransition,
+			name:   "Invalid State Transition",
+			from:   StatusComplete,
+			to:     StatusUpdate,
+			expErr: shift.ErrInvalidStateTransition,
+			expKVs: j.MKV{"from": StatusComplete, "to": StatusUpdate},
 		},
 		{
-			name:        "Unknown 'from' status",
-			from:        unknownShiftStatus,
-			to:          StatusUpdate,
-			expectedErr: errors.Wrap(shift.ErrUnknownStatus, "unknown 'from' status", j.MKV{"from ": fmt.Sprintf("%T", unknownShiftStatus), "to": fmt.Sprintf("%T", StatusUpdate)}),
+			name:   "Unknown 'from' status",
+			from:   unknownShiftStatus,
+			to:     StatusUpdate,
+			expErr: errors.Wrap(shift.ErrUnknownStatus, "unknown 'from' status"),
+			expKVs: j.MKV{"from": unknownShiftStatus, "to": StatusUpdate},
 		},
 		{
-			name:        "Unknown 'to' status",
-			from:        StatusUpdate,
-			to:          unknownShiftStatus,
-			expectedErr: errors.Wrap(shift.ErrUnknownStatus, "unknown 'to' status", j.MKV{"from ": fmt.Sprintf("%T", StatusUpdate), "to": fmt.Sprintf("%T", unknownShiftStatus)}),
+			name:   "Unknown 'to' status",
+			from:   StatusUpdate,
+			to:     unknownShiftStatus,
+			expErr: errors.Wrap(shift.ErrUnknownStatus, "unknown 'to' status"),
+			expKVs: j.MKV{"from": StatusUpdate, "to": unknownShiftStatus},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := fsm.Update(ctx, dbc, tt.from, tt.to, update{ID: id, Name: "updateMe", Amount: amount})
-			jtest.Assert(t, tt.expectedErr, err)
+			jtest.Assert(t, tt.expErr, err)
 		})
 	}
 }


### PR DESCRIPTION
### Fixed
- Error reporting for `to` and from `states`, we were just printing the types of the states before, rather than the actual states, e.g.:
```shell
            actual:   - message: invalid state transition
              code: ERR_be8211db784bfb67
              kv:
              - key: from
                value: package.CategoryStatus
              - key: to
                value: package.CategoryStatus
            message:  []
```