### PR TITLE
shift: Update reflex dependency and use rsql.DBC interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.6
 
 require (
 	github.com/luno/jettison v0.0.0-20240722160230-b42bd507a5f6
-	github.com/luno/reflex v0.0.0-20230911104529-cc0924a36b7c
+	github.com/luno/reflex v0.0.0-20241129142022-57682f2c87b2
 	github.com/sebdah/goldie/v2 v2.5.3
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/tools v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/luno/jettison v0.0.0-20240722160230-b42bd507a5f6 h1:0s90//MXlAOvp91eN
 github.com/luno/jettison v0.0.0-20240722160230-b42bd507a5f6/go.mod h1:cV8KOstEDY+Su4dcN1dadoXC7xmyEqtXAw6Nywia/z8=
 github.com/luno/reflex v0.0.0-20230911104529-cc0924a36b7c h1:Axrjn+QKQbpBgAiqQcyKcTy2UAYlUt5AVZ/vFB1sryc=
 github.com/luno/reflex v0.0.0-20230911104529-cc0924a36b7c/go.mod h1:oZEWD0P1CBTfFncvN2bkvGa9rGe51T9ltxHcwsLCtyU=
+github.com/luno/reflex v0.0.0-20241129142022-57682f2c87b2 h1:91otoSwPMeL6ZoG7rSwo/T0YULXCA/uT6zhFJJwr6o4=
+github.com/luno/reflex v0.0.0-20241129142022-57682f2c87b2/go.mod h1:q7RkMP4b1yr3/6/6Q4zDkKkh777nIYYXFSHwjDXURNU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=

--- a/shift.go
+++ b/shift.go
@@ -99,7 +99,7 @@ type ValidatingUpdater[T primary] interface {
 // eventInserter inserts reflex events into a sql DB table.
 // It is implemented by rsql.EventsTable or rsql.EventsTableInt.
 type eventInserter[T primary] interface {
-	InsertWithMetadata(ctx context.Context, tx *sql.Tx, foreignID T,
+	InsertWithMetadata(ctx context.Context, dbc rsql.DBC, foreignID T,
 		typ reflex.EventType, metadata []byte) (rsql.NotifyFunc, error)
 }
 


### PR DESCRIPTION
This updates the reflex module version and implements a change needed to allow continued support which is to use `rsql.DBC` instead of `*sql.Tx`
