### PR TITLE
go: Update to 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         mysql: ['mysql:8']
-        go: ['1.22', '1']
+        go: ['1.23', '1']
         
     services:
       mysql:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/luno/shift
 
-go 1.21
-
-toolchain go1.22.6
+go 1.24
 
 require (
 	github.com/luno/jettison v0.0.0-20240722160230-b42bd507a5f6


### PR DESCRIPTION
### Changed
- Update to 1.24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Go version used in testing workflows to include Go 1.23.
  - Updated Go module version to 1.24 and removed the explicit toolchain directive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->