### PR TITLE
sonar: Add mysql8 to sonar test run

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -30,7 +30,7 @@ jobs:
           go-version: '1.24'
 
       - name: Generate Sonar Report
-        run: go test -db_test_base="root@tcp(localhost:${{ job.services.mysql.ports[3306] }})/test?" -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json
+        run: go test -db_test_base="root@tcp(localhost:${{ job.services.mysql.ports['3306'] }})/test" -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json
 
       - name: Upload coverage reports to Sonar
         env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,6 +10,17 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: test
+        ports:
+          - 3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        
     steps:
       - uses: actions/checkout@v4
 
@@ -19,7 +30,7 @@ jobs:
           go-version: '1.24'
 
       - name: Generate Sonar Report
-        run: go test -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json
+        run: go test -db_test_base="root@tcp(localhost:${{ job.services.mysql.ports[3306] }})/test?" -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json
 
       - name: Upload coverage reports to Sonar
         env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -30,7 +30,7 @@ jobs:
           go-version: '1.24'
 
       - name: Generate Sonar Report
-        run: go test -db_test_base="root@tcp(localhost:${{ job.services.mysql.ports['3306'] }})/test" -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json
+        run: go test -db_test_base="root@tcp(localhost:${{ job.services.mysql.ports[3306] }})/test?" -coverpkg=./... -coverprofile=coverage.out -json ./... > sonar-report.json
 
       - name: Upload coverage reports to Sonar
         env:


### PR DESCRIPTION
- Mirrors unit test pipeline
- Wasn't failing on MRs as we only run this job on main branch merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the test workflow to include a MySQL 8 service for enhanced test execution.
  - Adjusted test commands to connect with the new MySQL service during workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->