### PR TITLE
chore: bump go.mod to 1.26.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,14 @@ jobs:
 
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v6
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version-file: 'go.mod'
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v6
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         mysql: ['mysql:8']
-        go: ['1']
         
     services:
       mysql:
@@ -32,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ matrix.go }}
+        go-version-file: 'go.mod'
       id: go
 
     - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/shift
 
-go 1.25.3
+go 1.26.0
 
 toolchain go1.26.1
 


### PR DESCRIPTION
Bump the `go` directive in `go.mod` to `1.26.0`. The `toolchain go1.26.1` line is retained.